### PR TITLE
Updated TweenTransition

### DIFF
--- a/src/examples/transitions/TweenTransition/example.js
+++ b/src/examples/transitions/TweenTransition/example.js
@@ -58,15 +58,20 @@ define(function(require, exports, module) {
     });
 
     Transitionable.registerMethod('tween', TweenTransition);
+    var transitionable = new Transitionable(1);
+
+    modifier.opacityFrom(function() {
+        return transitionable.get();
+    });
 
     var transition = {
         method: 'tween',
         curve: "easeInOut",
-        period: 1500,
+        duration: 1500,
     };
     
     surface.on("click", function(){
-        modifier.setOpacity(0,transition);
+        transitionable.set(0, transition);
     });
 
     mainContext.add(modifier).add(surface);


### PR DESCRIPTION
- Replaced deprecated function `setOpacity` with `opacityFrom`. [http://famo.us/docs/0.1.1/core/Modifier/#setOpacity](http://famo.us/docs/0.1.1/core/Modifier/#setOpacity)
- Updated _Transition_ options value.
