### PR TITLE
update git modules to point to http instead of git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/famous"]
 	path = src/famous
-	url = git@github.com:Famous/famous.git
+	url = https://github.com/Famous/famous.git


### PR DESCRIPTION
This solves #28  and #25 more elegantly

I also think it might be worth switching this repo over to the new project formate... it would be possible to make a grunt task to automate switching between examples.
