### PR TITLE
Prevent possible npm-debug.log to be commited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public/*bundle.*
 node_modules/
+npm-debug.log


### PR DESCRIPTION
Related to #50.
